### PR TITLE
Update the make file to work with drush 5.x

### DIFF
--- a/tanarurkerem_ckeditor.make
+++ b/tanarurkerem_ckeditor.make
@@ -10,8 +10,8 @@ projects[ckeditor][subdir] = "contrib"
 libraries[ckeditor][download][type] = "file"
 libraries[ckeditor][download][url] = "http://download.cksource.com/CKEditor/CKEditor/CKEditor%203.6.2/ckeditor_3.6.2.tar.gz"
 
-projects[tanarurkerem_ckeditor][type] = module
-projects[tanarurkerem_ckeditor][subdir] = features
-projects[tanarurkerem_ckeditor][download][type] = git
-projects[tanarurkerem_ckeditor][download][url] = git://github.com/tanarurkerem/tanarurkerem_ckeditor.git
-
+projects[tanarurkerem_ckeditor_feature][type] = module
+projects[tanarurkerem_ckeditor_feature][subdir] = features
+projects[tanarurkerem_ckeditor_feature][download][type] = git
+projects[tanarurkerem_ckeditor_feature][download][url] = git://github.com/tanarurkerem/tanarurkerem_ckeditor.git
+projects[tanarurkerem_ckeditor_feature][directory_name] = tanarurkerem_ckeditor


### PR DESCRIPTION
Druhs make in drush 5.x run the ./[PROJECTNAME].make file in a downloaded project,
and if this make file refers to self project drush make will run int an endless loop.

So if a project contains a make file for build itself, it should refer itself
with a different project name, and specify the right directory name.
